### PR TITLE
Disable too-few-public-methods

### DIFF
--- a/base-flakeheaven.toml
+++ b/base-flakeheaven.toml
@@ -25,4 +25,5 @@ pylint = [
     "-C0301", # line-too-long -> already covered by flake E501 
     "-C0411", # wrong-import-order - this will be handled by isort
     "-F6401", # cannot-enumerate-pytest-fixtures
+    "-R0903", # too-few-public-methods - we don't necessarily see this as a bad thing
 ]


### PR DESCRIPTION
Even though this check for refactoring code is helpful in some cases it
rarily helps us refactoring anything. Everytime it shows up we usually
will just disable it. Other cases where we would actually refactor this
would probably be pointed out in code reviews.

Ref:
- https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/too-few-public-methods.html