### PR TITLE
Ignore flake8 rule incompatible with black

### DIFF
--- a/base-flakeheaven.toml
+++ b/base-flakeheaven.toml
@@ -16,7 +16,7 @@ max_line_length = 88
 pyflakes = ["-F401"] # __init__ files can have imports just to allow "shortcuts"
 
 [tool.flakeheaven.plugins]
-pycodestyle = ["+*", "-W503", "-W504", "-W605"]
+pycodestyle = ["+*", "-E203", "-W503", "-W504", "-W605"]
 pyflakes = ["+*"]
 "flake8-*" = ["+*", "-Q000"]
 mccabe = ["+*"]


### PR DESCRIPTION
E203 is a rule incompatible with black.
https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#configuration

Apart from that, this particular rule is incompatible with pep8 (see the link above for more information).