### PR TITLE
Disable C0415 checks on conftest.py

### DIFF
--- a/base-flakeheaven.toml
+++ b/base-flakeheaven.toml
@@ -31,3 +31,8 @@ pylint = [
     "-F6401", # cannot-enumerate-pytest-fixtures
     "-R0903", # too-few-public-methods - we don't necessarily see this as a bad thing
 ]
+
+[tool.flakeheaven.exceptions."**/conftest.py"]
+pylint = [
+    "-C0415", # import-outside-toplevel - importing on toplevel can affect mocking
+]


### PR DESCRIPTION
This check is usually disabled in our conftest.py files because it can impair mocking.